### PR TITLE
Add Animator and property animation hooks

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -44,14 +44,14 @@
 |--|---|-----------|
 |3.1|✔| `struct Keyframe<T> { start:u32,end:u32,start_v:T,end_v:T,ease:CubicBezier }`.|
 |3.2|✔| `fn sample(&self, frame:f32) -> T` using ease LUT (256 entries).|
-|3.3| | `Animator<T>` stores `Vec<Keyframe<T>>`. Implement `Animator::value(frame)`.|
-|3.4| | Attach animators to `Transform` and fill/style props within each `Layer` via `HashMap<&'static str, Animator<Value>>`.|
+|3.3|✔| `Animator<T>` stores `Vec<Keyframe<T>>`. Implement `Animator::value(frame)`.|
+|3.4|✔| Attach animators to `Transform` and fill/style props within each `Layer` via `HashMap<&'static str, Animator<Value>>`.|
 
 ---
 ## 4 Raster Back‑Ends
 |ID| ✔ | Instruction|
 |--|---|-----------|
-|4.1| | `renderer::cpu` → implement `draw_path(Path, Paint, &mut [u8], w,h,stride)` in RGBA8888.|
+|4.1|✔| `renderer::cpu` → implement `draw_path(Path, Paint, &mut [u8], w,h,stride)` in RGBA8888.|
 |4.2| | Enable SIMD span‑fill with `packed_simd_2` behind `simd` feature; provide scalar fallback.|
 |4.3| | `renderer::embedded_graphics` adapter that implements `embedded_graphics::Drawable` for `Composition`.|
 |4.4| | `renderer::wasm` produce `ImageData` via wasm‑bindgen; compile under `wasm32-unknown-unknown`.|

--- a/rlottie_core/Cargo.toml
+++ b/rlottie_core/Cargo.toml
@@ -17,3 +17,6 @@ serde_json = "1.0"
 smallvec = "1.11"
 lyon = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
+
+[dev-dependencies]
+image = "0.25.6"

--- a/rlottie_core/src/lib.rs
+++ b/rlottie_core/src/lib.rs
@@ -5,5 +5,6 @@
 
 pub mod geometry;
 pub mod loader;
+pub mod renderer;
 pub mod timeline;
 pub mod types;

--- a/rlottie_core/src/loader/json.rs
+++ b/rlottie_core/src/loader/json.rs
@@ -5,6 +5,7 @@
 
 use crate::types::{Composition, Layer, PathCommand, ShapeLayer, Vec2};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::io::Read;
 
 /// Load a composition from a reader containing Lottie JSON.
@@ -33,7 +34,10 @@ pub fn from_reader<R: Read>(mut reader: R) -> Result<Composition, Box<dyn std::e
                         }
                     }
                 }
-                layers.push(Layer::Shape(ShapeLayer { paths }));
+                layers.push(Layer::Shape(ShapeLayer {
+                    paths,
+                    animators: HashMap::new(),
+                }));
             }
         }
     }

--- a/rlottie_core/src/renderer/mod.rs
+++ b/rlottie_core/src/renderer/mod.rs
@@ -1,0 +1,4 @@
+//! Module: rendering backends
+//! Mirrors: rlottie/src/vpainter.cpp (simplified)
+
+pub mod cpu;


### PR DESCRIPTION
## Summary
- implement `Animator<T>` with `value()` sampling function
- integrate animator support in `Transform` and `ShapeLayer`
- parse default animators in JSON loader
- add CPU renderer with basic draw_path
- update roadmap and include solid fill test

## Testing
- `cargo fmt --all`
- `cargo check --all-features --workspace`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo +nightly doc --all-features --no-deps`
- `cargo bloat --release -n 0 | grep TOTAL` (produced no TOTAL output)


------
https://chatgpt.com/codex/tasks/task_e_688bf38b2d9083339f87697ee48c418b