### PR TITLE
Add stubbed golden hash test

### DIFF
--- a/doc/TODO-TESTING.md
+++ b/doc/TODO-TESTING.md
@@ -23,9 +23,9 @@
 ## 1 Golden Frame Hash Tests
 | ID | ✔ | Instruction |
 |----|----|-------------|
-|1.1| | Add `tests/golden_hash.rs` that iterates corpus, renders same frames via **Rust** engine, converts to PNG (or raw RGBA) and hashes.|
+|1.1|✔| Add `tests/golden_hash.rs` that iterates corpus, renders same frames via **Rust** engine, converts to PNG (or raw RGBA) and hashes.|
 |1.2| | Assert computed SHA‑256 matches reference hash ± optional tolerance (allow ≤ 5 pixel diff → fallback to RMSE check).|
-|1.3| | Bite‑size: implement helper `fn render_hash(anim:&Composition, frame:u32)->[u8;32]`.|
+|1.3|✔| Bite‑size: implement helper `fn render_hash(anim:&Composition, frame:u32)->[u8;32]`.|
 
 ---
 ## 2 Visual Diff CLI

--- a/rlottie_core/Cargo.toml
+++ b/rlottie_core/Cargo.toml
@@ -21,3 +21,5 @@ wasm-bindgen = { version = "0.2", optional = true }
 [dev-dependencies]
 proptest = "1"
 image = "0.25.6"
+sha2 = "0.10"
+hex = "0.4"

--- a/rlottie_core/tests/golden_hash.rs
+++ b/rlottie_core/tests/golden_hash.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use rlottie_core::loader::json;
+
+mod util;
+
+fn load_hashes() -> HashMap<String, String> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../tests/assets/hashes.json");
+    let data = fs::read_to_string(path).unwrap();
+    serde_json::from_str(&data).unwrap()
+}
+
+/// Compare rendered frames with C++ reference hashes.
+#[test]
+#[ignore]
+fn golden_hash_corpus() {
+    let hashes = load_hashes();
+    let corpus_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../tests/assets/corpus");
+    let frames = [0u32, 30, 60];
+
+    for entry in fs::read_dir(corpus_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read(&path).unwrap();
+        let comp = json::from_slice(&data).unwrap();
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        for &frame in &frames {
+            let digest = util::render_hash(&comp, frame);
+            let key = format!("tests/assets/corpus/{file_name}_{frame}.png");
+            if let Some(expect) = hashes.get(&key) {
+                assert_eq!(hex::encode(digest), *expect, "hash mismatch for {key}");
+            } else {
+                panic!("missing hash entry for {key}");
+            }
+        }
+    }
+}

--- a/rlottie_core/tests/testutil.rs
+++ b/rlottie_core/tests/testutil.rs
@@ -21,5 +21,6 @@ pub fn transform_strategy() -> impl Strategy<Value = Transform> {
             scale,
             rotation,
             opacity,
+            animators: std::collections::HashMap::new(),
         })
 }

--- a/rlottie_core/tests/util.rs
+++ b/rlottie_core/tests/util.rs
@@ -1,0 +1,15 @@
+use rlottie_core::types::Composition;
+use sha2::{Digest, Sha256};
+
+pub fn render_hash(anim: &Composition, frame: u32) -> [u8; 32] {
+    let width = 240usize;
+    let height = 240usize;
+    let mut buf = vec![0u8; width * height * 4];
+    anim.render_sync(frame, &mut buf, width, height, width * 4);
+    let mut hasher = Sha256::new();
+    hasher.update(&buf);
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}

--- a/tests/golden_hash.rs
+++ b/tests/golden_hash.rs
@@ -1,0 +1,1 @@
+../rlottie_core/tests/golden_hash.rs

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,1 @@
+../rlottie_core/tests/util.rs


### PR DESCRIPTION
## Summary
- mark TODO checklist for golden hash harness
- disable golden hash test by default

## Testing
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo +nightly doc --all-features --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_688c341ed37483339a8d90b9ee8805e0