### PR TITLE
Add benchmark and loader task entries

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -71,7 +71,7 @@
 
 ---
 ## 6 Performance & Size
-- [ ] Add `benches/render.rs` using `criterion`; measure ms/frame 240×240 @ 60 fps.
+- [x] Add `benches/render.rs` using `criterion`; measure ms/frame 240×240 @ 60 fps.
 - [ ] Integrate `cargo bloat --release` in CI; fail if binary > 600 kB (embedded profile).
 - [ ] SIMD vs scalar regression → bench group tags.
 - [ ] Tile cache: static layer bitmaps reused across frames.
@@ -96,4 +96,12 @@
 
 ---
 *(Testing roadmap will be authored in **/doc/TODO-TESTING.doc**.)
+
+---
+## 10 Loader Feature Gate
+- [ ] Add `loader` Cargo feature gating JSON parser; default `loader` on.
+- [ ] Mark `pub mod loader` and JSON functions with `#[cfg(feature = "loader")]`.
+- [ ] Update tests/examples to enable `loader` when required.
+- [ ] Provide `examples/pre_render.rs` to convert JSON to frame bitmaps.
+- [ ] Document embedded workflow in `README.md`.
 

--- a/rlottie_core/Cargo.toml
+++ b/rlottie_core/Cargo.toml
@@ -27,6 +27,7 @@ proptest = "1"
 wasm-bindgen-test = "0.3"
 sha2 = "0.10"
 hex = "0.4"
+criterion = "0.5"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rlottie_core/benches/render.rs
+++ b/rlottie_core/benches/render.rs
@@ -1,0 +1,23 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use rlottie_core::loader::json;
+use std::path::Path;
+
+fn bench_render(c: &mut Criterion) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../tests/assets/corpus/1643-exploding-star.json");
+    let data = std::fs::read(path).unwrap();
+    let comp = json::from_slice(&data).unwrap();
+    let width = 240usize;
+    let height = 240usize;
+    let mut buf = vec![0u8; width * height * 4];
+    c.bench_function("render_60_frames", |b| {
+        b.iter(|| {
+            for frame in 0..60u32 {
+                comp.render_sync(frame, &mut buf, width, height, width * 4);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_render);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- checklist: note loader feature tasks
- add Criterion benchmark for rendering

## Testing
- `cargo fmt --all`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo +nightly doc --all-features --no-deps`
- `cargo bloat --release --bin rlottie_examples -n 0 | tail -n 1`
- `cargo bench --bench render -- --test`


------
https://chatgpt.com/codex/tasks/task_e_688ce6d52b58833391268ba12e745243